### PR TITLE
Allow users to set component names in remote state

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -2,7 +2,7 @@ module "aws_saml" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component  = "aws-saml"
+  component  = var.aws_saml_component_name
   privileged = true
 
   ignore_errors = true

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -30,3 +30,9 @@ variable "trusted_github_repos" {
     EOT
   default     = {}
 }
+
+variable "aws_saml_component_name" {
+  type        = string
+  description = "The name of the aws-saml component"
+  default     = "aws-saml"
+}


### PR DESCRIPTION
Allow users to set component names in remote state.

* Defined input variable `aws_saml_component_name`.
* Variable defaults to preserving the behaviour of the current version.
* Remote state uses this variable to pull in the state of the components.
* This update allows the codebase to adopt more standardized structure and naming practices.

